### PR TITLE
Get all executions

### DIFF
--- a/src/Executions.ts
+++ b/src/Executions.ts
@@ -8,7 +8,7 @@ export default class Executions {
     public static async deleteAll() {
         this.validateBaseUrl()
 
-        const { data } = await this.axios.get(`${this.baseUrl}/executions`)
+        const data = await this.getAll()
         const promises: Promise<any>[] = []
 
         for (const execution of data ?? []) {
@@ -16,6 +16,10 @@ export default class Executions {
         }
 
         await Promise.all(promises)
+    }
+
+    public static async getAll(): Promise<{ id: string }[]> {
+        return (await this.axios.get(`${this.baseUrl}/executions`)).data
     }
 
     public static deleteExecution(id: string): Promise<any> {

--- a/src/__tests__/behavioral/Executions.test.ts
+++ b/src/__tests__/behavioral/Executions.test.ts
@@ -5,6 +5,7 @@ import AbstractSpruceTest, {
     generateId,
 } from '@sprucelabs/test-utils'
 import Executions from '../../Executions'
+import { ExecutionDetails } from '../../nodeNeuropype.types'
 import AxiosStub from '../../testDoubles/AxiosStub'
 import { generateFakedAxiosResponse } from '../../testDoubles/generateFakedAxiosResponse'
 
@@ -68,6 +69,38 @@ export default class ExecutionsTest extends AbstractSpruceTest {
         this.assertDeletAtIndexUsedId(1, '0001')
     }
 
+    @test()
+    protected static async canGetInfoOnASingleExecution() {
+        const data = {
+            state: { running: false },
+        }
+        this.axiosStub.fakedGetResponse = generateFakedAxiosResponse(
+            JSON.stringify(data)
+        )
+        const actual = await Executions.getDetails('0000')
+
+        assert.isEqual(
+            this.axiosStub.lastGetUrl,
+            `${process.env.NEUROPYPE_BASE_URL}/executions/0000`
+        )
+        assert.isEqualDeep(actual, data)
+    }
+
+    @test()
+    protected static async canGetInfoOnASingleExecutionWithInvalidJson() {
+        const details = this.validJsonWithInfinity()
+        this.axiosStub.fakedGetResponse = generateFakedAxiosResponse(
+            JSON.stringify(details).replaceAll('"Infinity"', 'Infinity')
+        )
+        const actual = await Executions.getDetails('0000')
+
+        assert.isEqual(
+            this.axiosStub.lastGetUrl,
+            `${process.env.NEUROPYPE_BASE_URL}/executions/0000`
+        )
+        assert.isEqualDeep(actual, details)
+    }
+
     private static assertDeletAtIndexUsedId(idx: number, id: string) {
         assert.isEqualDeep(this.axiosStub.deleteParamsHistory[idx], {
             url: `${process.env.NEUROPYPE_BASE_URL}/executions/${id}`,
@@ -76,5 +109,54 @@ export default class ExecutionsTest extends AbstractSpruceTest {
 
     private static async deleteAll() {
         await Executions.deleteAll()
+    }
+
+    private static validJsonWithInfinity(): ExecutionDetails {
+        return {
+            state: {
+                running: false,
+                calibrating: false,
+                had_errors: false,
+                paused: false,
+                needs_keepalive: false,
+                completed: false,
+                status: '',
+            },
+            graph: {
+                nodes: [
+                    {
+                        uuid: 'd5ee6868-f6cb-41bc-ade1-440d5ab2f8e9',
+                        type: 'DejitterTimestamps',
+                        id: 0,
+                        parameters: [
+                            {
+                                id: 'set_breakpoint',
+                                value_domain: [0, 'Infinity'],
+                                value: false,
+                                port_type: 'BoolPort',
+                                value_type: 'builtins.bool',
+                            },
+                        ],
+                    },
+                ],
+                description: {
+                    url: '',
+                    name: '',
+                    description: '',
+                    status: '',
+                    license: '',
+                    version: '',
+                },
+                edges: [],
+            },
+            info: {
+                debug_hooks: [],
+                tickrate: 0,
+                log_level: 0,
+                error_mode: '',
+            },
+            id: 0,
+            errors: [],
+        }
     }
 }

--- a/src/nodeNeuropype.types.ts
+++ b/src/nodeNeuropype.types.ts
@@ -25,3 +25,87 @@ export interface PipelineNode {
     id: string
     type: string
 }
+
+export interface ExecutionDetails {
+    state: State
+    info: Info
+    id: number
+    graph: Graph
+    errors: any[]
+}
+
+export interface Graph {
+    description: Description
+    nodes: Node[]
+    edges: Edge[]
+}
+
+export interface Description {
+    url: string
+    name: string
+    description: string
+    status: string
+    license: string
+    version: string
+}
+
+export interface Edge {
+    source_node: number
+    source_port: string
+    target_port: string
+    id: number
+    target_node: number
+}
+
+export interface Node {
+    id: number
+    parameters: Parameter[]
+    type: string
+    uuid: string
+}
+
+export interface Parameter {
+    value: number[] | boolean | ValueClass | number | null | string
+    value_type: ValueType
+    port_type: PortType
+    value_domain: (number | 'Infinity' | '-Infinity')[] | null
+    id: string
+}
+
+export type PortType =
+    | 'BoolPort'
+    | 'DictPort'
+    | 'EnumPort'
+    | 'FloatPort'
+    | 'IntPort'
+    | 'ListPort'
+    | 'Port'
+    | 'StringPort'
+
+export interface ValueClass {}
+
+export type ValueType =
+    | 'builtins.bool'
+    | 'builtins.dict'
+    | 'builtins.float'
+    | 'builtins.int'
+    | 'builtins.list'
+    | 'builtins.object'
+    | 'builtins.str'
+
+export interface Info {
+    debug_hooks: any[]
+    tickrate: number
+    log_level: number
+    error_mode: string
+}
+
+export interface State {
+    calibrating: boolean
+    had_errors: boolean
+    paused: boolean
+    needs_keepalive: boolean
+    completed: boolean
+    status: string
+    running: boolean
+}


### PR DESCRIPTION
Adds the capability to delete a single execution, get the info for a single execution, and exposes the call to get all executions.

I discovered that neuropype sends [JSON5](https://json5.org/), which can fail if we try to parse it as normal JSON. 