### PR TITLE
patch: Executions.getDetails tests id changes

### DIFF
--- a/src/__tests__/behavioral/Executions.test.ts
+++ b/src/__tests__/behavioral/Executions.test.ts
@@ -77,11 +77,11 @@ export default class ExecutionsTest extends AbstractSpruceTest {
         this.axiosStub.fakedGetResponse = generateFakedAxiosResponse(
             JSON.stringify(data)
         )
-        const actual = await Executions.getDetails('0000')
+        const actual = await Executions.getDetails('1234')
 
         assert.isEqual(
             this.axiosStub.lastGetUrl,
-            `${process.env.NEUROPYPE_BASE_URL}/executions/0000`
+            `${process.env.NEUROPYPE_BASE_URL}/executions/1234`
         )
         assert.isEqualDeep(actual, data)
     }


### PR DESCRIPTION
@eric-yates - the test was not thorough. I added a small tweak to make sure the right ID was passed to Executions.getDetails()

I confirmed the tests were not covering by hardcoding 0000 into the call made in Executions.getDetails() and the tests still passed.